### PR TITLE
Upgrade to rspec 2.14.0

### DIFF
--- a/rspec-http.gemspec
+++ b/rspec-http.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_runtime_dependency "rspec", "~> 2.0"
+  s.add_runtime_dependency "rspec", "~> 2.14.0"
 end
 


### PR DESCRIPTION
We have a couple of projects which are being upgraded to rspec 2.14.0 and rspec-http is currently locked to '~> 2.0' causing problems with the upgrade. Please merge this PR when you plan to release a new version of this gem.
Thanks.
